### PR TITLE
Tiny typo fixes

### DIFF
--- a/slides/04_Stochastic-Gradient-Descent/SGD.tex
+++ b/slides/04_Stochastic-Gradient-Descent/SGD.tex
@@ -70,7 +70,7 @@
 
   \begin{itemize}
     \item requires only \textbf{one} gradient instead of $n$ per iteration.
-    \item we call $g_t := \nabla f_i(x_k)$ a \textcolor{blue}{stochastic gradient} (estimator)
+    \item we call $g_k := \nabla f_i(x_k)$ a \textcolor{blue}{stochastic gradient} (estimator)
   \end{itemize}
 \end{frame}
 
@@ -245,7 +245,7 @@
   \begin{itemize}
     \item Previous proof can be extended (trivially) to the constrained setting
     \item with same complexity $\mathcal{O}(\epsilon^{-2})$
-    \item but (ofcourse) additionaly
+    \item but (of course) additionaly
   \end{itemize}
 
 \end{frame}


### PR DESCRIPTION
Stochastic gradient subscript k not t.