### PR TITLE
Typo in Lipschitz bound & interact not defined

### DIFF
--- a/exercises/04_SGD/notebook/Lab 5 - Stochastic Gradient Descent.ipynb
+++ b/exercises/04_SGD/notebook/Lab 5 - Stochastic Gradient Descent.ipynb
@@ -317,7 +317,7 @@
    "metadata": {},
    "source": [
     "## Assuming bounded expected stochastic gradients\n",
-    "Assume we are moving in a bounded region $\\|x\\| \\leq 25$ containing all iterates (and we assume $\\|x-x^\\star\\| \\leq 25$ as well, for simplicity). By $\\nabla f(x) = \\frac{1}{n}A^\\top (Ax - b)$, one can see that $f$ is Lipschitz over that bounded region, with Lipschitz constant $\\|\\nabla f(x)\\| \\leq \\frac{1}{n} (\\|A^\\top A\\|\\|x\\| + \\|A^\\top Ab\\|)$. We also know that $E\\big[\\|g_t\\|\\big | x_t\\big]\\ = \\nabla f(x)$. So to find B such that  $E\\big[\\|g_t\\|^2\\big]\\leq B^2$, we need to compute the Lipschitz constant."
+    "Assume we are moving in a bounded region $\\|x\\| \\leq 25$ containing all iterates (and we assume $\\|x-x^\\star\\| \\leq 25$ as well, for simplicity). By $\\nabla f(x) = \\frac{1}{n}A^\\top (Ax - b)$, one can see that $f$ is Lipschitz over that bounded region, with Lipschitz constant $\\|\\nabla f(x)\\| \\leq \\frac{1}{n} (\\|A^\\top A\\|\\|x\\| + \\|A^\\top b\\|)$. We also know that $E\\big[\\|g_t\\|\\big | x_t\\big]\\ = \\nabla f(x)$. So to find B such that  $E\\big[\\|g_t\\|^2\\big]\\leq B^2$, we need to compute the Lipschitz constant."
    ]
   },
   {
@@ -362,7 +362,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "interact(plot_figure, n_iter=IntSlider(min=1, max=len(sgd_xs_dec_gamma)))"
+    "# interact(plot_figure, n_iter=IntSlider(min=1, max=len(sgd_xs_dec_gamma)))"
    ]
   },
   {


### PR DESCRIPTION
Removed additional A in Lipschitz constant bound.
Got "NameError: name 'interact' is not defined". Tried to load interact from ipywidgets, but then function plot_figure not defined. Can we simply ignore this cell?