### PR TITLE
[Fix] fix Concrete_Data instead of Concrete_data

### DIFF
--- a/exercises/04_SGD/notebook/Stochastic Gradient Descent.ipynb
+++ b/exercises/04_SGD/notebook/Stochastic Gradient Descent.ipynb
@@ -567,7 +567,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data = np.loadtxt(\"Concrete_data.csv\",delimiter=\",\")\n",
+    "data = np.loadtxt(\"Concrete_Data.csv\",delimiter=\",\")\n",
     "\n",
     "A = data[:,:-1]\n",
     "b = data[:,-1]\n",


### PR DESCRIPTION
homogenize the file name Concrete_Data instead of  Concrete_data for the reading of the file in the notebook.