### PR TITLE
change best_loss initialization and add missing print statements

### DIFF
--- a/exercises/08_Momentum/momentum.ipynb
+++ b/exercises/08_Momentum/momentum.ipynb
@@ -306,7 +306,7 @@
     "plt.xlabel(\"Learning rate\")\n",
     "plt.ylabel(\"Best loss seen\")\n",
     "\n",
-    "best_loss = None\n",
+    "best_loss = np.inf\n",
     "best_learning_rate = None\n",
     "\n",
     "grid = ### TODO, find a reasonable range, of values to try\n",
@@ -328,7 +328,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f\"The learning rate {best_learning_rate} worked well for SGD without momentum.\""
+    "print(f\"The learning rate {best_learning_rate} worked well for SGD without momentum.\")"
    ]
   },
   {
@@ -347,7 +347,7 @@
     "plt.xlabel(\"Learning rate\")\n",
     "plt.ylabel(\"Best loss seen\")\n",
     "\n",
-    "best_loss = None\n",
+    "best_loss = np.inf\n",
     "best_learning_rate = None\n",
     "\n",
     "# The grid is chosen by trial and error in this case, \n",
@@ -370,7 +370,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "f\"The learning rate {best_learning_rate} worked well for SGD with 0.9 momentum.\""
+    "print(f\"The learning rate {best_learning_rate} worked well for SGD with 0.9 momentum.\")"
    ]
   },
   {


### PR DESCRIPTION
I guess to compare the achieved loss in the first iteration the best_loss needs to be initialized with a high number so that the achieved loss in the first iteration is lower (since comparing to None does not work)