### PR TITLE
minor naming update on SGD slide 10

### DIFF
--- a/slides/05_Stochastic-Gradient-Descent/SGD.tex
+++ b/slides/05_Stochastic-Gradient-Descent/SGD.tex
@@ -41,7 +41,7 @@
           \end{equation}
     \item evaluating $\nabla f$ can be \textbf{expensive} if $n$ is large
   \end{itemize}
-  
+
 \end{frame}
 
 
@@ -178,7 +178,7 @@
 
   By convexity we have that
   \begin{itemize}
-    \item $B_{GD}^2 \approx \left\Vert \frac{1}{n}\sum_{i=1}^{n}\nabla f_i(x) \right\Vert^2 \le \frac{1}{n} \sum_{i=1}^{n} \Vert \nabla f_i(x) \Vert^2 \approx B_{SGD}^2$
+    \item $B_{BG}^2 \approx \left\Vert \frac{1}{n}\sum_{i=1}^{n}\nabla f_i(x) \right\Vert^2 \le \frac{1}{n} \sum_{i=1}^{n} \Vert \nabla f_i(x) \Vert^2 \approx B_{SGD}^2$
     \item but usually comparable
   \end{itemize}
 \end{frame}


### PR DESCRIPTION
You mentioned this change on the lecture. It's just minor naming change to keep the slide consistent.